### PR TITLE
Made changes to label generation wizard for UPS. #6059

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ from party import Address
 from carrier import Carrier, UPSService
 from sale import Configuration, Sale
 from stock import (
-    ShipmentOut, StockMove, GenerateUPSLabelMessage, GenerateUPSLabel,
+    ShipmentOut, StockMove, ShippingUps, GenerateShippingLabel
 )
 from configuration import UPSConfiguration
 
@@ -25,10 +25,11 @@ def register():
         Sale,
         StockMove,
         ShipmentOut,
-        GenerateUPSLabelMessage,
+        ShippingUps,
         module='ups', type_='model'
     )
+
     Pool.register(
-        GenerateUPSLabel,
+        GenerateShippingLabel,
         module='ups', type_='wizard'
     )

--- a/stock.xml
+++ b/stock.xml
@@ -8,24 +8,10 @@
             <field name="inherit" ref="stock.shipment_out_view_form"/>
             <field name="name">shipment_view_form</field>
         </record>
-
-        <!-- Generate Labels -->
-        <record model="ir.action.wizard" id="wizard_generate_ups_label">
-            <field name="name">Generate UPS Label</field>
-            <field name="wiz_name">generate.ups.label</field>
-            <field name="model">stock.shipment.out</field>
-        </record>
-
-        <record model="ir.action.keyword" id="act_wizard_generate_ups_labels">
-            <field name="keyword">form_action</field>
-            <field name="model">stock.shipment.out,-1</field>
-            <field name="action" ref="wizard_generate_ups_label"/>
-        </record>
-
-        <record model="ir.ui.view" id="generate_ups_label_message_view_form">
-            <field name="model">generate.ups.label.message</field>
+        <record model="ir.ui.view" id="shipping_ups_configuration_view_form">
+            <field name="model">shipping.label.ups</field>
             <field name="type">form</field>
-            <field name="name">generate_ups_label_message_view_form</field>
+            <field name="name">shipping_ups_configuration_form</field>
         </record>
 
     </data>

--- a/view/generate_ups_label_message_view_form.xml
+++ b/view/generate_ups_label_message_view_form.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<form string="UPS Labels Generated" col="2">
-    <image name="tryton-attachment" xexpand="0" xfill="0"/>
-    <label string="Shipment labels have been generated via UPS and saved as attachments for the shipment" id="ups_labels_generate"/>
-    <newline/>
-    <label name="tracking_number"/>
-    <field name="tracking_number"/>
-</form>

--- a/view/shipping_ups_configuration_form.xml
+++ b/view/shipping_ups_configuration_form.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form string="UPS Configuration">
+     <label name="ups_service_type"/>
+     <field name="ups_service_type"/>
+     <label name="ups_package_type"/>
+     <field name="ups_package_type"/>
+     <label name="ups_saturday_delivery"/>
+     <field name="ups_saturday_delivery"/>
+</form>


### PR DESCRIPTION
1. Pushed the super call in `update_shipment()` to the beginning so that UPS-specific changes are saved properly.
2. Minor changes to wizard. Adjusted design due to shipping refactoring.
